### PR TITLE
feat: handle errors with types.ValidationResponse

### DIFF
--- a/internal/controller/awsvalidator_controller.go
+++ b/internal/controller/awsvalidator_controller.go
@@ -122,6 +122,7 @@ func (r *AwsValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		awsAPI, err := aws_utils.NewAwsAPI(validator.Spec.Auth, rule.Region)
 		if err != nil {
 			r.Log.V(0).Error(err, "failed to reconcile AMI rule")
+			resp.AddResult(nil, err)
 			continue
 		}
 		amiRuleService := ami.NewAmiRuleService(r.Log, awsAPI.EC2)
@@ -174,6 +175,7 @@ func (r *AwsValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		awsAPI, err := aws_utils.NewAwsAPI(validator.Spec.Auth, rule.Region)
 		if err != nil {
 			r.Log.V(0).Error(err, "failed to reconcile Service Quota rule")
+			resp.AddResult(nil, err)
 			continue
 		}
 		svcQuotaService := servicequota.NewServiceQuotaRuleService(
@@ -196,6 +198,7 @@ func (r *AwsValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		awsAPI, err := aws_utils.NewAwsAPI(validator.Spec.Auth, rule.Region)
 		if err != nil {
 			r.Log.V(0).Error(err, "failed to reconcile Tag rule")
+			resp.AddResult(nil, err)
 			continue
 		}
 		tagRuleService := tag.NewTagRuleService(r.Log, awsAPI.EC2)


### PR DESCRIPTION
Part of our work to standardize error handling across plugins.

This plugin already used `types.ValidationResponse` but in some situations, did not add the error to it before moving onto the next rule.