### PR TITLE
fix: YAML rendering of structs embedded in rules

### DIFF
--- a/api/v1alpha1/awsvalidator_types.go
+++ b/api/v1alpha1/awsvalidator_types.go
@@ -102,7 +102,7 @@ type AwsSTSAuth struct {
 // Each AmiRule is intended to match a single AMI, as an AmiRule is considered successful if at least one AMI is found.
 // Refer to https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html for more information.
 type AmiRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	RuleName string   `json:"name" yaml:"name"`
 	AmiIDs   []string `json:"amiIds,omitempty" yaml:"amiIds,omitempty"`
@@ -132,7 +132,7 @@ type Filter struct {
 
 // IamRoleRule compares the IAM permissions associated with an IAM role against an expected permission set.
 type IamRoleRule struct {
-	validationrule.AutomaticallyNamed `json:",inline"`
+	validationrule.AutomaticallyNamed `json:",inline" yaml:",omitempty"`
 
 	IamRoleName string           `json:"iamRoleName" yaml:"iamRoleName"`
 	Policies    []PolicyDocument `json:"iamPolicies" yaml:"iamPolicies"`
@@ -152,7 +152,7 @@ func (r IamRoleRule) IAMPolicies() []PolicyDocument {
 
 // IamUserRule compares the IAM permissions associated with an IAM user against an expected permission set.
 type IamUserRule struct {
-	validationrule.AutomaticallyNamed `json:",inline"`
+	validationrule.AutomaticallyNamed `json:",inline" yaml:",omitempty"`
 
 	IamUserName string           `json:"iamUserName" yaml:"iamUserName"`
 	Policies    []PolicyDocument `json:"iamPolicies" yaml:"iamPolicies"`
@@ -172,7 +172,7 @@ func (r IamUserRule) IAMPolicies() []PolicyDocument {
 
 // IamGroupRule compares the IAM permissions associated with an IAM group against an expected permission set.
 type IamGroupRule struct {
-	validationrule.AutomaticallyNamed `json:",inline"`
+	validationrule.AutomaticallyNamed `json:",inline" yaml:",omitempty"`
 
 	IamGroupName string           `json:"iamGroupName" yaml:"iamGroupName"`
 	Policies     []PolicyDocument `json:"iamPolicies" yaml:"iamPolicies"`
@@ -192,7 +192,7 @@ func (r IamGroupRule) IAMPolicies() []PolicyDocument {
 
 // IamPolicyRule compares the IAM permissions associated with an IAM policy against an expected permission set.
 type IamPolicyRule struct {
-	validationrule.AutomaticallyNamed `json:",inline"`
+	validationrule.AutomaticallyNamed `json:",inline" yaml:",omitempty"`
 
 	IamPolicyARN string           `json:"iamPolicyArn" yaml:"iamPolicyArn"`
 	Policies     []PolicyDocument `json:"iamPolicies" yaml:"iamPolicies"`
@@ -243,7 +243,7 @@ func (c Condition) String() string {
 
 // ServiceQuotaRule ensures that AWS service quotas are within a particular threshold.
 type ServiceQuotaRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	RuleName      string         `json:"name" yaml:"name"`
 	Region        string         `json:"region" yaml:"region"`
@@ -271,7 +271,7 @@ type ServiceQuota struct {
 
 // TagRule ensures that the tags associated with a particular AWS resource match an expected tag set.
 type TagRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	RuleName      string   `json:"name" yaml:"name"`
 	Key           string   `json:"key" yaml:"key"`


### PR DESCRIPTION
## Description
In previous PRs, we made the plugin rules implement the new `validationrule.Interface` interface. We did not include YAML tags in rules to specify that the new field (`validationrule.ManuallyNamed` or `validationrule.AutomaticallyNamed` depending on the rule) should not be included when the rules are rendered to YAML. The validatorctl CLI renders the rules to YAML as part of what it does, so this caused errors when validatorctl tried to apply validator CRDs it generated to its cluster.

This fixes it by adding the YAML tags.