### PR TITLE
fix: panic when evaluating IAM user rules

### DIFF
--- a/pkg/validators/iam/iam_validator.go
+++ b/pkg/validators/iam/iam_validator.go
@@ -412,6 +412,10 @@ func checkSCP(iamSvc iamAPI, policyDocs []v1alpha1.PolicyDocument, policySourceA
 			}
 
 			for _, result := range simResults {
+				// Not all simulation results will have this field (ie. when service control policies are not used).
+				if result.OrganizationsDecisionDetail == nil {
+					continue
+				}
 				if !result.OrganizationsDecisionDetail.AllowedByOrganizations && result.EvalDecision != "allowed" {
 					// append SCP failure
 					scpFailures = append(scpFailures, fmt.Sprintf("Action: %s is denied due to an Organization level SCP policy for %s: %s", *result.EvalActionName, policySourceType, policySourceName))


### PR DESCRIPTION
## Issue
Fixes https://github.com/validator-labs/validator-plugin-aws/issues/502.

## Description
Fixes the issue by checking for nil first during IAM rule evaluation.
